### PR TITLE
Clean up pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,8 +77,8 @@
         <!-- project settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
         <license-plugin.version>5.0.0</license-plugin.version>
 
         <!-- compile dependency version management -->

--- a/pom.xml
+++ b/pom.xml
@@ -82,35 +82,12 @@
         <license-plugin.version>5.0.0</license-plugin.version>
 
         <!-- compile dependency version management -->
-        <slf4j.version>1.7.30</slf4j.version>
         <rdf4j.version>5.3.2</rdf4j.version>
         <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <!-- provided dependency version management -->
         <spotbugs.version>4.10.2</spotbugs.version>
-        <!-- test dependency version management -->
-        <groovy.version>3.0.25</groovy.version>
-        <spock.version>2.4-groovy-3.0</spock.version>
-        <gmavenplus.version>5.0.0</gmavenplus.version>
-        <surefire.version>3.6.0-M1</surefire.version>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- test -->
-            <dependency>
-                <groupId>org.codehaus.groovy</groupId>
-                <artifactId>groovy</artifactId>
-                <version>${groovy.version}</version>
-                <scope>test</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.spockframework</groupId>
-                <artifactId>spock-core</artifactId>
-                <version>${spock.version}</version>
-                <scope>test</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <!-- provided -->
         <dependency>
@@ -122,38 +99,7 @@
     </dependencies>
 
     <build>
-        <testSourceDirectory>src/test/groovy</testSourceDirectory>
-        <!-- TODO: the repo does not have any tests, so why do we have plugins for surefire, gmavenplus, groovy, spock, ...? -->
-        <pluginManagement>
-            <plugins>
-                <plugin>
-                    <groupId>org.codehaus.gmavenplus</groupId>
-                    <artifactId>gmavenplus-plugin</artifactId>
-                    <version>${gmavenplus.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>compileTests</goal>
-                            </goals>
-                            <configuration>
-                                <parallelParsing>true</parallelParsing>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
-        </pluginManagement>
         <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>${surefire.version}</version>
-                <configuration>
-                    <printSummary>false</printSummary>
-                    <includes>
-                        <include>**/*Spec.*</include>
-                    </includes>
-                </configuration>
-            </plugin>
             <plugin>
                 <groupId>com.mycila</groupId>
                 <artifactId>license-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <!-- compile dependency version management -->
         <slf4j.version>1.7.30</slf4j.version>
         <rdf4j.version>5.3.2</rdf4j.version>
-        <flatten.version>1.7.3</flatten.version>
+        <flatten-maven-plugin.version>1.7.3</flatten-maven-plugin.version>
         <!-- provided dependency version management -->
         <spotbugs.version>4.10.2</spotbugs.version>
         <!-- test dependency version management -->
@@ -176,7 +176,7 @@
                 <!-- https://www.mojohaus.org/flatten-maven-plugin/usage.html -->
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>flatten-maven-plugin</artifactId>
-                <version>${flatten.version}</version>
+                <version>${flatten-maven-plugin.version}</version>
                 <configuration>
                     <updatePomFile>true</updatePomFile>
                     <flattenMode>resolveCiFriendliesOnly</flattenMode>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
     <properties>
         <!-- project version -->
         <!-- https://maven.apache.org/maven-ci-friendly.html#multi-module-setup -->
-        <revision>0.2.0</revision>
+        <revision>0.2.1</revision>
 
         <!-- project settings -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/rdf-resource-resolver-api/pom.xml
+++ b/rdf-resource-resolver-api/pom.xml
@@ -42,5 +42,10 @@
             <artifactId>rdf4j-rio-api</artifactId>
             <version>${rdf4j.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-model</artifactId>
+            <version>${rdf4j.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/rdf-resource-resolver-core/src/main/java/org/fairdatateam/rdf/resolver/core/ContentNegotiationStrategy.java
+++ b/rdf-resource-resolver-core/src/main/java/org/fairdatateam/rdf/resolver/core/ContentNegotiationStrategy.java
@@ -28,7 +28,6 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Optional;
-import org.apache.http.HttpHeaders;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 /**
@@ -37,18 +36,23 @@ import org.eclipse.rdf4j.rio.RDFFormat;
  * header will be checked against the available {@link RDFFormat}s for matching values.
  */
 public class ContentNegotiationStrategy extends AbstractResolverStrategy {
+
+    private final static String HTTP_HEADER_ACCEPT = "Accept";
+
+    private final static String HTTP_HEADER_CONTENT_TYPE = "Content-Type";
+
     @Override
     protected HttpRequest configureRequest(String iri) {
         return HttpRequest.newBuilder()
                 .uri(URI.create(iri))
-                .header(HttpHeaders.ACCEPT, ACCEPT_PARAMS)
+                .header(HTTP_HEADER_ACCEPT, ACCEPT_PARAMS)
                 .build();
     }
 
     @Override
     protected Optional<RDFFormat> resolveFormat(HttpResponse<InputStream> response) {
         return response.headers()
-                .firstValue(HttpHeaders.CONTENT_TYPE)
+                .firstValue(HTTP_HEADER_CONTENT_TYPE)
                 .flatMap(format -> RDFFormat.matchMIMEType(format, FORMATS));
     }
 }

--- a/rdf-resource-resolver-core/src/main/java/org/fairdatateam/rdf/resolver/core/PathExtensionStrategy.java
+++ b/rdf-resource-resolver-core/src/main/java/org/fairdatateam/rdf/resolver/core/PathExtensionStrategy.java
@@ -28,13 +28,15 @@ import java.net.URI;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Optional;
-import org.apache.http.HttpHeaders;
 import org.eclipse.rdf4j.rio.RDFFormat;
 
 /**
  * Resolver strategy based on matching the file extension in the URL context path.
  */
 public class PathExtensionStrategy extends AbstractResolverStrategy {
+
+    private final static String HTTP_HEADER_LOCATION = "Location";
+
     @Override
     protected HttpRequest configureRequest(String iri) {
         return HttpRequest.newBuilder()
@@ -45,7 +47,7 @@ public class PathExtensionStrategy extends AbstractResolverStrategy {
     @Override
     protected Optional<RDFFormat> resolveFormat(HttpResponse<InputStream> response) {
         var path = response.headers()
-                .firstValue(HttpHeaders.LOCATION)
+                .firstValue(HTTP_HEADER_LOCATION)
                 .map(URI::create)
                 .orElseGet(response::uri)
                 .getPath();


### PR DESCRIPTION
- bumped package version from 0.2.0 to 0.2.1
- removed unused version properties from pom.xml
- removed unused test dependencies (the package does not even have tests)
- removed imports from `org.apache.http` (replaced by raw strings) because this is no longer available after recent dependency upgrades (probably the package was available transitively before)
- added explicit dependency on `rdf4j-model` because this imported explicitly in the code